### PR TITLE
fix: correct eslint plugin config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,13 +2,11 @@
   "extends": [
     "next/core-web-vitals",
     "eslint:recommended",
-    "@typescript-eslint/recommended",
-    "prettier"
+    "plugin:@typescript-eslint/recommended"
   ],
   "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint", "prettier"],
+  "plugins": ["@typescript-eslint"],
   "rules": {
-    "prettier/prettier": "error",
     "@typescript-eslint/no-unused-vars": "error",
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/explicit-function-return-type": "off",


### PR DESCRIPTION
## Summary
- fix ESLint config to use `plugin:@typescript-eslint/recommended`
- remove unused Prettier references to prevent missing module errors

## Testing
- `npm run lint` *(fails: numerous `@typescript-eslint/no-unused-vars` errors across project)*
- `npm run type-check` *(ran but produced no output, process terminated)*
- `npx jest` *(fails: 403 Forbidden fetching jest package)*
- `npm run build` *(fails: `MinIOService` not exported from `@/lib/minio-client`)*

------
https://chatgpt.com/codex/tasks/task_e_688e13d29868832b94404ff9c7091664


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Resumo por Sourcery

Corrigir configuração do ESLint e remover referências não utilizadas do Prettier

Correções de Bugs:
- Atualizar a configuração do ESLint para usar o preset de plugin recomendado do @typescript-eslint

Tarefas:
- Remover entradas obsoletas de plugins do Prettier para evitar erros de módulo ausente

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix ESLint configuration and remove unused Prettier references

Bug Fixes:
- Update ESLint config to use the recommended @typescript-eslint plugin preset

Chores:
- Remove obsolete Prettier plugin entries to prevent missing module errors

</details>