### PR TITLE
feat: enforce auth and roles on attachments and comments

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -91,6 +91,29 @@ export const verifyJWT = (token: string): any => {
   }
 }
 
+// Verifica se o usuário tem permissão para acessar um ticket
+export const canUserAccessTicket = async (
+  userId: string,
+  role: string | undefined,
+  ticketId: string
+) => {
+  if (!userId) return false
+
+  // Coordenadores e administradores têm acesso total
+  if (role === 'ADMIN' || role === 'COORDINATOR') {
+    return true
+  }
+
+  const ticket = await prisma.ticket.findUnique({
+    where: { id: ticketId },
+    select: { createdById: true, assignedToId: true }
+  })
+
+  if (!ticket) return false
+
+  return ticket.createdById === userId || ticket.assignedToId === userId
+}
+
 // Middleware de autorização
 export const requireAuth = (handler: any) => {
   return async (req: any, res: any) => {


### PR DESCRIPTION
## Summary
- add helper to verify ticket access based on role and ownership
- require session and ticket permissions for attachment actions
- protect comment endpoints with role-aware ticket checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e1d0261ec832b9e427adb42e320a7


> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.

## Resumo por Sourcery

Aplicar autenticação e controle de acesso baseado em função nos endpoints de anexos e comentários usando uma nova função auxiliar `canUserAccessTicket` para retornar as respostas 401/403 apropriadas para requisições não autorizadas.

Novas Funcionalidades:
- Adicionar a função auxiliar `canUserAccessTicket` para verificar o acesso a tickets com base na função e propriedade do usuário.
- Exigir sessão do usuário e permissões de ticket para os endpoints de anexos (download, upload, listagem).
- Proteger os endpoints de comentários (GET, POST) com verificações de acesso a tickets baseadas em sessão e cientes da função.

Melhorias:
- Substituir os TODOs de permissão por validação de acesso real e retornar as respostas 401/403 apropriadas.
- Usar o ID do usuário da sessão autenticada nos logs de auditoria em vez de valores de placeholder.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce authentication and role-based access control on attachments and comments endpoints using a new `canUserAccessTicket` helper to return proper 401/403 responses for unauthorized requests.

New Features:
- Add `canUserAccessTicket` helper to verify ticket access based on user role and ownership.
- Require user session and ticket permissions for attachments endpoints (download, upload, list).
- Protect comments endpoints (GET, POST) with session-based, role-aware ticket access checks.

Enhancements:
- Replace permission TODOs with actual access validation and return appropriate 401/403 responses.
- Use authenticated session user ID in audit logs instead of placeholder values.

</details>