### PR TITLE
feat: add supabase admin helpers

### DIFF
--- a/env.example
+++ b/env.example
@@ -15,6 +15,13 @@ NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your_nextauth_secret_key_here_min_32_chars
 
 # ========================================
+# CONFIGURAÇÕES DO SUPABASE
+# ========================================
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+
+# ========================================
 # CONFIGURAÇÕES DE AUTENTICAÇÃO
 # ========================================
 JWT_SECRET=your_jwt_secret_key_here_min_32_chars

--- a/env.example
+++ b/env.example
@@ -17,7 +17,8 @@ NEXTAUTH_SECRET=your_nextauth_secret_key_here_min_32_chars
 # ========================================
 # CONFIGURAÇÕES DO SUPABASE
 # ========================================
-NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+# Use a URL completa da sua instância Supabase (ex.: http://localhost:54321 ao self-hosting)
+NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -6,6 +6,49 @@ import { createClient } from '@supabase/supabase-js'
 // which will cause requests to fail fast and alert maintainers to properly
 // configure the environment.
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
 
-export const supabase = createClient(supabaseUrl, supabaseKey)
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabaseAdmin = createClient(supabaseUrl, supabaseServiceRoleKey)
+
+// Helper para validar a existência de variáveis de ambiente necessárias
+export const validateSupabaseEnv = (): void => {
+  const required = [
+    'NEXT_PUBLIC_SUPABASE_URL',
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    'SUPABASE_SERVICE_ROLE_KEY'
+  ]
+
+  required.forEach((key) => {
+    if (!process.env[key]) {
+      throw new Error(`Variável de ambiente ausente: ${key}`)
+    }
+  })
+}
+
+// Helper para criação de usuário usando o client administrativo
+export interface CreateUserParams {
+  email: string
+  password: string
+  metadata?: Record<string, any>
+}
+
+export const createUser = async ({ email, password, metadata }: CreateUserParams) => {
+  const { data, error } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    password,
+    user_metadata: metadata,
+    email_confirm: true
+  })
+
+  if (error) throw error
+  return data.user
+}
+
+// Helper genérico para leitura de tabelas
+export const readTable = async (table: string) => {
+  const { data, error } = await supabase.from(table).select('*')
+  if (error) throw error
+  return data
+}


### PR DESCRIPTION
## Summary
- add Supabase service role client for admin operations
- expose helpers for env validation, user creation and table reads
- document Supabase env vars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*
- `npm run type-check` *(fails: various type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e1f39d970832b9e0ec80d8a9f4748

## Resumo por Sourcery

Disponibiliza o cliente de função de serviço Supabase e funções auxiliares de administração relacionadas para validação de ambiente, criação de usuário e consultas de tabela

Novas Funcionalidades:
- Adiciona o cliente `supabaseAdmin` para operações administrativas
- Introduz a função auxiliar `validateSupabaseEnv` para garantir a presença das variáveis de ambiente Supabase obrigatórias
- Adiciona a função auxiliar `createUser` para criar usuários via cliente administrativo Supabase
- Adiciona a função auxiliar `readTable` para leituras genéricas de tabela

Documentação:
- Atualiza `env.example` para documentar `SUPABASE_SERVICE_ROLE_KEY`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose Supabase service role client and related admin helpers for environment validation, user creation, and table queries

New Features:
- Add supabaseAdmin client for admin operations
- Introduce validateSupabaseEnv helper to enforce required Supabase env vars
- Add createUser helper to create users via Supabase admin client
- Add readTable helper for generic table reads

Documentation:
- Update env.example to document SUPABASE_SERVICE_ROLE_KEY

</details>