### PR TITLE
feat: add supabase admin helpers

### DIFF
--- a/env.example
+++ b/env.example
@@ -15,6 +15,14 @@ NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your_nextauth_secret_key_here_min_32_chars
 
 # ========================================
+# CONFIGURAÇÕES DO SUPABASE
+# ========================================
+# Use a URL completa da sua instância Supabase (ex.: http://localhost:54321 ao self-hosting)
+NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key
+SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
+
+# ========================================
 # CONFIGURAÇÕES DE AUTENTICAÇÃO
 # ========================================
 JWT_SECRET=your_jwt_secret_key_here_min_32_chars

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -6,6 +6,60 @@ import { createClient } from '@supabase/supabase-js'
 // which will cause requests to fail fast and alert maintainers to properly
 // configure the environment.
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ''
-const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ''
+const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || ''
 
-export const supabase = createClient(supabaseUrl, supabaseKey)
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+let cachedAdminClient: ReturnType<typeof createClient> | null = null
+export const getSupabaseAdmin = () => {
+  if (!supabaseServiceRoleKey) {
+    throw new Error('Variável de ambiente ausente: SUPABASE_SERVICE_ROLE_KEY')
+  }
+  if (!cachedAdminClient) {
+    cachedAdminClient = createClient(supabaseUrl, supabaseServiceRoleKey)
+  }
+  return cachedAdminClient
+}
+
+// Helper para validar a existência de variáveis de ambiente necessárias
+export const validateSupabaseEnv = (): void => {
+  const required = [
+    'NEXT_PUBLIC_SUPABASE_URL',
+    'NEXT_PUBLIC_SUPABASE_ANON_KEY',
+    'SUPABASE_SERVICE_ROLE_KEY'
+  ]
+
+  required.forEach((key) => {
+    if (!process.env[key]) {
+      throw new Error(`Variável de ambiente ausente: ${key}`)
+    }
+  })
+}
+
+// Helper para criação de usuário usando o client administrativo
+export interface CreateUserParams {
+  email: string
+  password: string
+  metadata?: Record<string, unknown>
+}
+
+export const createUser = async ({ email, password, metadata }: CreateUserParams) => {
+  const admin = getSupabaseAdmin()
+  const { data, error } = await admin.auth.admin.createUser({
+    email,
+    password,
+    user_metadata: metadata,
+    email_confirm: true
+  })
+
+  if (error) throw error
+  return data.user
+}
+
+// Helper genérico para leitura de tabelas
+export const readTable = async (table: string) => {
+  const { data, error } = await supabase.from(table).select('*')
+  if (error) throw error
+  return data
+}


### PR DESCRIPTION
## Summary
- add Supabase service role client for admin operations
- expose helpers for env validation, user creation and table reads
- document Supabase env vars and self-hosted URL example

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: see errors)*
- `npm run type-check` *(fails: see errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e1f39d970832b9e0ec80d8a9f4748