### PR TITLE
feat: add MinIO service

### DIFF
--- a/app/api/attachments/download-minio/[id]/route.ts
+++ b/app/api/attachments/download-minio/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { MinIOService } from '@/lib/minio-client';
+import { extractKeyFromUrl, getSignedDownloadUrl } from '@/lib/minio-service';
 import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions, canUserAccessTicket } from '@/lib/auth';
@@ -69,11 +69,11 @@ export async function GET(
 
     try {
       // Extrair key da URL do MinIO
-      const key = MinIOService.extractKeyFromUrl(attachment.url);
+      const key = extractKeyFromUrl(attachment.url);
       console.log(`🔑 Key extraída: ${key}`);
 
       // Gerar URL assinada para download (válida por 1 hora)
-      const signedUrl = await MinIOService.getSignedDownloadUrl(key, 3600);
+      const signedUrl = await getSignedDownloadUrl(key, 3600);
       console.log(`✅ URL assinada gerada`);
 
       // Log da ação de download

--- a/app/api/attachments/upload-minio/route.ts
+++ b/app/api/attachments/upload-minio/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { MinIOService } from '@/lib/minio-client';
+import { uploadFile } from '@/lib/minio-service';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 
@@ -119,12 +119,11 @@ export async function POST(request: NextRequest) {
     // Gerar nome único para o arquivo
     const timestamp = Date.now();
     const randomSuffix = Math.random().toString(36).substring(2, 8);
-    const fileExtension = file.name.split('.').pop() || '';
     const sanitizedName = file.name.replace(/[^a-zA-Z0-9.-]/g, '_');
     const uniqueFileName = `${timestamp}_${randomSuffix}_${sanitizedName}`;
 
     // Upload para MinIO
-    const fileUrl = await MinIOService.uploadFile(
+    const fileUrl = await uploadFile(
       buffer,
       uniqueFileName,
       file.type,
@@ -236,7 +235,7 @@ export async function POST(request: NextRequest) {
 }
 
 // Método OPTIONS para CORS
-export async function OPTIONS(request: NextRequest) {
+export async function OPTIONS() {
   return new NextResponse(null, {
     status: 200,
     headers: {

--- a/lib/minio-service.ts
+++ b/lib/minio-service.ts
@@ -1,0 +1,53 @@
+import {
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { minioClient, minioConfig } from './minio-client';
+
+export async function uploadFile(
+  file: Buffer,
+  fileName: string,
+  contentType: string,
+  metadata?: Record<string, string>,
+): Promise<string> {
+  const key = `attachments/${fileName}`;
+  await minioClient.send(
+    new PutObjectCommand({
+      Bucket: minioConfig.bucketName,
+      Key: key,
+      Body: file,
+      ContentType: contentType,
+      Metadata: metadata,
+    }),
+  );
+  return `${minioConfig.publicUrl}/${minioConfig.bucketName}/${key}`;
+}
+
+export function extractKeyFromUrl(url: string): string {
+  const { pathname } = new URL(url);
+  const [, , ...rest] = pathname.split('/');
+  return rest.join('/');
+}
+
+export async function getSignedDownloadUrl(
+  key: string,
+  expiresIn = 3600,
+): Promise<string> {
+  const cmd = new GetObjectCommand({
+    Bucket: minioConfig.bucketName,
+    Key: key,
+  });
+  return getSignedUrl(minioClient, cmd, { expiresIn });
+}
+
+export async function deleteFile(key: string): Promise<void> {
+  await minioClient.send(
+    new DeleteObjectCommand({
+      Bucket: minioConfig.bucketName,
+      Key: key,
+    }),
+  );
+}
+

--- a/lib/minio-service.ts
+++ b/lib/minio-service.ts
@@ -22,7 +22,20 @@ export async function uploadFile(
       Metadata: metadata,
     }),
   );
-  return `${minioConfig.publicUrl}/${minioConfig.bucketName}/${key}`;
+  function joinUrlParts(...parts: string[]): string {
+    return parts
+      .map((part, idx) => {
+        if (idx === 0) return part.replace(/\/+$/, ''); // remove trailing slash from first part
+        if (idx === parts.length - 1) return part.replace(/^\/+/, ''); // remove leading slash from last part
+        return part.replace(/^\/+|\/+$/g, ''); // remove leading and trailing slashes from middle parts
+      })
+      .filter(Boolean)
+      .join('/');
+  }
+
+  const publicUrl = minioConfig.publicUrl.replace(/\/+$/, '');
+  const bucketName = minioConfig.bucketName.replace(/^\/+|\/+$/g, '');
+  return joinUrlParts(publicUrl, bucketName, key);
 }
 
 export function extractKeyFromUrl(url: string): string {

--- a/lib/minio-service.ts
+++ b/lib/minio-service.ts
@@ -26,9 +26,23 @@ export async function uploadFile(
 }
 
 export function extractKeyFromUrl(url: string): string {
-  const { pathname } = new URL(url);
-  const [, , ...rest] = pathname.split('/');
-  return rest.join('/');
+  try {
+    const { pathname } = new URL(url);
+    const parts = pathname.split('/');
+    // Expecting: ['', bucketName, ...keyParts]
+    if (parts.length < 3 || !parts[1] || !parts[2]) {
+      throw new Error(`Malformed MinIO URL: ${url}`);
+    }
+    const [, , ...rest] = parts;
+    const key = rest.join('/');
+    if (!key) {
+      throw new Error(`Could not extract key from URL: ${url}`);
+    }
+    return key;
+  } catch (err) {
+    // Optionally, you could log the error here
+    throw new Error(`Invalid URL provided to extractKeyFromUrl: ${url}. Error: ${(err as Error).message}`);
+  }
 }
 
 export async function getSignedDownloadUrl(

--- a/lib/minio-service.ts
+++ b/lib/minio-service.ts
@@ -45,10 +45,21 @@ export function extractKeyFromUrl(url: string): string {
   }
 }
 
+const MIN_EXPIRES_IN = 60; // 1 minute
+const MAX_EXPIRES_IN = 604800; // 7 days
+
 export async function getSignedDownloadUrl(
   key: string,
   expiresIn = 3600,
 ): Promise<string> {
+  if (typeof expiresIn !== 'number' || isNaN(expiresIn)) {
+    throw new Error('expiresIn must be a number');
+  }
+  if (expiresIn < MIN_EXPIRES_IN || expiresIn > MAX_EXPIRES_IN) {
+    throw new Error(
+      `expiresIn must be between ${MIN_EXPIRES_IN} and ${MAX_EXPIRES_IN} seconds`
+    );
+  }
   const cmd = new GetObjectCommand({
     Bucket: minioConfig.bucketName,
     Key: key,


### PR DESCRIPTION
## Summary
- add stateless MinIO helper functions for uploads, key extraction, signed URLs, and deletion
- update attachment API routes to call the new helpers

## Testing
- `npm test` (fails: Missing script "test")
- `npx eslint app/api/attachments/download-minio/[id]/route.ts app/api/attachments/upload-minio/route.ts lib/minio-service.ts` (warnings: no-console)


------
https://chatgpt.com/codex/tasks/task_e_688e1f2ac318832ba43e08935e0ed915

## Resumo por Sourcery

Integrar o serviço MinIO introduzindo funções auxiliares reutilizáveis e atualizando os endpoints da API de anexos para aproveitar essas utilidades para o gerenciamento de arquivos.

Novas Funcionalidades:
- Adicionar funções auxiliares MinIO sem estado para upload de arquivos, extração de chaves, geração de URL assinado e exclusão.

Melhorias:
- Atualizar as rotas da API de anexos para usar as novas funções auxiliares MinIO para operações de arquivo.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate MinIO service by introducing reusable helper functions and updating attachment API endpoints to leverage these utilities for file management.

New Features:
- Add stateless MinIO helper functions for file upload, key extraction, signed URL generation, and deletion.

Enhancements:
- Update attachment API routes to use new MinIO helper functions for file operations.

</details>